### PR TITLE
fix(scripts): fix URL defaults and payload quoting bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 state/
 logs/
 workspace/*/
+.worktrees/
 
 # Dependencies
 node_modules/

--- a/scripts/daily-polemic-queue.sh
+++ b/scripts/daily-polemic-queue.sh
@@ -34,7 +34,7 @@ MOLTBOT_STATE_DIR="${MOLTBOT_STATE_DIR:-/workspace}"
 STATE_DIR="${MOLTBOT_STATE_DIR}/daily-polemic"
 STATE_FILE="$STATE_DIR/rotation-state.json"
 # AI Generator URL - use localhost when running on host, container name in Docker
-AI_GENERATOR_URL="${AI_GENERATOR_URL:-http://localhost:3002}"
+AI_GENERATOR_URL="${AI_GENERATOR_URL:-http://ai-generator:3000}"
 MOLTBOOK_API_URL="${MOLTBOOK_API_URL:-https://www.moltbook.com/api/v1}"
 MOLTBOOK_API_KEY="${MOLTBOOK_API_KEY:-}"
 TARGET_SUBMOLT="${POLEMIC_TARGET_SUBMOLT:-general}"

--- a/scripts/queue-submit-action.sh
+++ b/scripts/queue-submit-action.sh
@@ -68,7 +68,7 @@ fi
 
 ACTION_TYPE="$1"
 AGENT_NAME="$2"
-PAYLOAD="${3:-{}}"
+PAYLOAD="${3:-\{\}}"
 shift 2; [ $# -gt 0 ] && shift || true
 
 # Convert action type to lowercase (API expects lowercase)


### PR DESCRIPTION
### **User description**
## Summary

- **daily-polemic-queue.sh**: `AI_GENERATOR_URL` defaulted to `http://localhost:3002` which is unreachable inside Docker containers. Corrected to `http://ai-generator:3000` (the Docker service name), matching the pattern used by `convene-council.sh` and other scripts.
- **queue-submit-action.sh**: `PAYLOAD="${3:-{}}"` corrupted every non-empty payload by appending a stray `}`. Bash parses `"${3:-{}}"` as `${3:-{}` (parameter expansion with default `{`) followed by a literal `}` before the closing `"`. Fixed to `"${3:-\{\}}"` so the empty-payload default is correctly `{}`.

## Root Cause

The `${3:-{}}` bug caused every `queue-submit-action.sh` invocation with a payload to produce invalid JSON, silently breaking all queue submissions that went through it (daily polemic, any future callers).

## Test plan

- [ ] Run `daily-polemic-queue.sh` inside classical-philosopher container — should generate content and queue successfully
- [ ] Verify action appears in action-queue: `curl http://localhost:3008/actions`
- [ ] Confirm no stray `}` in submitted payloads by inspecting action-queue DB


___

### **PR Type**
Bug fix


___

### **Description**
- Fix AI_GENERATOR_URL default from unreachable localhost:3002 to Docker service name ai-generator:3000

- Fix payload quoting bug in queue-submit-action.sh that appended stray } to all non-empty payloads

- Correct bash parameter expansion syntax to properly handle empty JSON object default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["daily-polemic-queue.sh<br/>localhost:3002"] -->|Fix| B["ai-generator:3000<br/>Docker service"]
  C["queue-submit-action.sh<br/>PAYLOAD with stray }"] -->|Fix| D["Correct JSON payload<br/>with escaped braces"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daily-polemic-queue.sh</strong><dd><code>Fix AI Generator URL for Docker environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/daily-polemic-queue.sh

<ul><li>Changed AI_GENERATOR_URL default from http://localhost:3002 to <br>http://ai-generator:3000<br> <li> Ensures script can reach AI Generator service when running inside <br>Docker containers</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/moltbot-philosopher/pull/15/files#diff-dae4934674c93b9a243d80e72dc0bf7e706ce1e26c5127d51a8831a01de0861e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>queue-submit-action.sh</strong><dd><code>Fix payload quoting in parameter expansion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/queue-submit-action.sh

<ul><li>Fixed PAYLOAD variable assignment from "${3:-{}}" to "${3:-\{\}}"<br> <li> Prevents bash parameter expansion from appending stray } to non-empty <br>payloads<br> <li> Ensures valid JSON is submitted to action queue</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/moltbot-philosopher/pull/15/files#diff-8b228bc1beb3e8555aaaa7d4d7cdbaa08c76dc0ab35a401fcd6dbe88586d525e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

