### PR TITLE
fix(action-queue): complete PostgreSQL migration configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -660,20 +660,21 @@ services:
     environment:
       - NODE_ENV=production
       - ACTION_QUEUE_PORT=3008
-      - QUEUE_DB_PATH=/data/action-queue.db
+      - DATABASE_URL=postgresql://noosphere_admin:${POSTGRES_PASSWORD:-changeme_noosphere_2026}@postgres:5432/action_queue
       - MOLTBOOK_API_KEY=${MOLTBOOK_API_KEY}
       - MOLTBOOK_API_BASE=http://egress-proxy:8082/api/v1
       - QUEUE_PROCESS_INTERVAL=5000
       - CONDITION_CHECK_INTERVAL=30000
       - LOG_LEVEL=info
     volumes:
-      - ./data/action-queue:/data:rw
       - ./logs:/app/logs:rw
     ports:
       - "3008:3008"
     networks:
       - moltbot-network
     depends_on:
+      postgres:
+        condition: service_healthy
       egress-proxy:
         condition: service_healthy
     mem_limit: 512M

--- a/scripts/queue-cli.sh
+++ b/scripts/queue-cli.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration
-QUEUE_URL="${ACTION_QUEUE_URL:-http://localhost:3006}"
+QUEUE_URL="${ACTION_QUEUE_URL:-http://localhost:3008}"
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary

Completes Phase 7.2 Action Queue PostgreSQL migration by fixing configuration that was missing from the original PR #27.

**Changes:**
- ✅ Replace orphaned `QUEUE_DB_PATH=/data/action-queue.db` with `DATABASE_URL` pointing to PostgreSQL
- ✅ Remove unused `./data/action-queue:/data:rw` volume mount (no longer needed for PostgreSQL)
- ✅ Add `postgres` service as explicit dependency with health check condition
- ✅ Fix `queue-cli.sh` port: 3006 → 3008 (matches actual action-queue service port)

## Why These Changes Matter

The action-queue service was migrated from SQLite to PostgreSQL but the docker-compose.yml configuration wasn't fully updated:

1. **QUEUE_DB_PATH**: Orphaned environment variable pointing to non-existent SQLite file
2. **Volume mount**: Unused storage mount wasting resources
3. **Missing dependency**: action-queue service didn't wait for postgres to be healthy
4. **queue-cli.sh bug**: CLI tool pointed to wrong port, making it non-functional

## Testing

- ✅ YAML validation passed
- ✅ All 14 queue submission scripts already use HTTP API (verified in audit)
- ✅ No SQLite direct access in scripts
- ✅ queue-cli.sh now points to correct service port

## Verification Steps

After merge:
- [ ] Start services: `docker-compose up -d`
- [ ] Check health: `curl http://localhost:3008/queue/health`
- [ ] Test CLI: `bash scripts/queue-cli.sh stats`
- [ ] Submit test action: `bash scripts/queue-submit-action.sh POST classical '{}'`